### PR TITLE
bug-fix: panic when default namespace is not found on apollo

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -87,7 +87,12 @@ func (d *Decoder) unmarshalRoot(val reflect.Value, pairesTree map[string]*PathTr
 			key = strings.Split(key, ",")[0]
 		}
 
-		node, ok := pairesTree[namespace].StartWith(key)
+		pathTire, ok := pairesTree[namespace]
+		if !ok {
+			continue
+		}
+
+		node, ok := pathTire.StartWith(key)
 		if ok && node.Value != nil {
 			paires["."] = node.Value.(string)
 		}


### PR DESCRIPTION
如果 apollo 上面没有 application 这个 namespace，同时结构体 Tag 上指定的 namespace 也不存在。程序会 panic